### PR TITLE
Clear pendingTrades after added, add unit test to cover bug

### DIFF
--- a/src/risktracker.cpp
+++ b/src/risktracker.cpp
@@ -16,6 +16,7 @@ int RiskTracker::updateRisk() {
         }
     }
     this->totalRisk += runningSum;
+    this->pendingTrades.clear();
     return 0;
 }
 

--- a/tst/test_traderisktracker.cpp
+++ b/tst/test_traderisktracker.cpp
@@ -28,3 +28,14 @@ TEST(TradeRiskTrackerTest, TrackerZeroTest) {
     riskTracker.updateRisk();
     EXPECT_NEAR(riskTracker.getRisk(), 0, 1e-4);
 }
+
+TEST(TradeRiskTrackerTest, TrackerNonZeroTest) {
+    std::vector<Trade> trackedTrades;
+    RiskTracker riskTracker(0, trackedTrades);
+    riskTracker.addTrade(Trade(10, true, 5.0));
+    riskTracker.updateRisk();
+    EXPECT_NEAR(riskTracker.getRisk(), 50.0, 1e-4);
+    riskTracker.addTrade(Trade(10, true, 5.0));
+    riskTracker.updateRisk();
+    EXPECT_NEAR(riskTracker.getRisk(), 100.0, 1e-4);
+}


### PR DESCRIPTION
1. Issue: This PR fixes a bug where pendingTrades vector is not cleared after trades have already been processed.
2. Changes: Added line to clear pendingTrades after trades have been added, added unit test to cover bug.
3. Bug found: pendingTrades vector not cleared after trades already processed, leading to duplicate trades being added to totalRisk.
4. Difficulties: My main struggle was in understanding how risk is meant to be calculated because I'm not familiar with financial concepts. Another difficulty was that I am super rusty at C++ and had to look syntax up frequently.
5. Improvements: Maybe include a formula for how risk should be calculated for the uninitiated.